### PR TITLE
Added msg files to install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ install(DIRECTORY launch/
    FILES_MATCHING PATTERN "*.launch"
 )
 
+install(DIRECTORY src
+   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+   FILES_MATCHING PATTERN "*.yaml"
+)
+
 if (CATKIN_ENABLE_TESTING)
   find_package(roslint)
   roslint_python()


### PR DESCRIPTION
When using install targets, the ubx_messages.yaml file was missing in the install space. Just added this to the CMakeLists